### PR TITLE
AEA-3348 - Enhance API AWS Lambda Logs 

### DIFF
--- a/packages/capabilityStatement/src/app.ts
+++ b/packages/capabilityStatement/src/app.ts
@@ -1,4 +1,4 @@
-import {APIGatewayProxyResult} from "aws-lambda"
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
 import {Logger, injectLambdaContext} from "@aws-lambda-powertools/logger"
 import middy from "@middy/core"
 import inputOutputLogger from "@middy/input-output-logger"
@@ -19,8 +19,15 @@ const logger = new Logger({serviceName: "capabilityStatement"})
  *
  */
 
-const lambdaHandler = async (): Promise<APIGatewayProxyResult> => {
+const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const targetSpineServer = process.env.TargetSpineServer
+  logger.appendKeys({
+    "nhsd-correlation-id": event.headers["nhsd-correlation-id"],
+    "x-request-id": event.headers["x-request-id"],
+    "nhsd-request-id": event.headers["nhsd-request-id"],
+    "x-correlation-id": event.headers["x-correlation-id"],
+    "apigw-request-id": event.requestContext.requestId
+  })
   logger.info(`hello world from sandbox logger - target spine server ${targetSpineServer}`)
 
   return {

--- a/packages/capabilityStatement/src/app.ts
+++ b/packages/capabilityStatement/src/app.ts
@@ -20,7 +20,6 @@ const logger = new Logger({serviceName: "capabilityStatement"})
  */
 
 const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  const targetSpineServer = process.env.TargetSpineServer
   logger.appendKeys({
     "nhsd-correlation-id": event.headers["nhsd-correlation-id"],
     "x-request-id": event.headers["x-request-id"],
@@ -28,7 +27,6 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     "x-correlation-id": event.headers["x-correlation-id"],
     "apigw-request-id": event.requestContext.requestId
   })
-  logger.info(`hello world from sandbox logger - target spine server ${targetSpineServer}`)
 
   return {
     statusCode: 200,

--- a/packages/getMyPrescriptions/src/app.ts
+++ b/packages/getMyPrescriptions/src/app.ts
@@ -20,6 +20,7 @@ const logger = new Logger({serviceName: "getMyPrescriptions"})
  */
 
 const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  logger.info(`APIGW Request ID: ${event.requestContext.requestId}`)
   const spineClient = createSpineClient()
 
   try {

--- a/packages/getMyPrescriptions/src/app.ts
+++ b/packages/getMyPrescriptions/src/app.ts
@@ -20,7 +20,13 @@ const logger = new Logger({serviceName: "getMyPrescriptions"})
  */
 
 const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  logger.info(`APIGW Request ID: ${event.requestContext.requestId}`)
+  logger.appendKeys({
+    "nhsd-correlation-id": event.headers["nhsd-correlation-id"],
+    "x-request-id": event.headers["x-request-id"],
+    "nhsd-request-id": event.headers["nhsd-request-id"],
+    "x-correlation-id": event.headers["x-correlation-id"],
+    "apigw-request-id": event.requestContext.requestId
+  })
   const spineClient = createSpineClient()
 
   try {

--- a/packages/sandbox/src/app.ts
+++ b/packages/sandbox/src/app.ts
@@ -1,4 +1,4 @@
-import {APIGatewayProxyResult} from "aws-lambda"
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
 import {Logger, injectLambdaContext} from "@aws-lambda-powertools/logger"
 import middy from "@middy/core"
 import inputOutputLogger from "@middy/input-output-logger"
@@ -19,7 +19,14 @@ const logger = new Logger({serviceName: "sandbox"})
  *
  */
 
-const lambdaHandler = async (): Promise<APIGatewayProxyResult> => {
+const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  logger.appendKeys({
+    "nhsd-correlation-id": event.headers["nhsd-correlation-id"],
+    "x-request-id": event.headers["x-request-id"],
+    "nhsd-request-id": event.headers["nhsd-request-id"],
+    "x-correlation-id": event.headers["x-correlation-id"],
+    "apigw-request-id": event.requestContext.requestId
+  })
   return {
     statusCode: 200,
     body: JSON.stringify(successData),

--- a/packages/sandbox/tests/test-handler.test.ts
+++ b/packages/sandbox/tests/test-handler.test.ts
@@ -2,13 +2,19 @@ import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
 import {handler} from "../src/app"
 import {expect, describe, it} from "@jest/globals"
 import {ContextExamples} from "@aws-lambda-powertools/commons"
+import {Logger} from "@aws-lambda-powertools/logger"
 import successData from "../examples/GetMyPrescriptions/Bundle/success.json"
 
 const dummyContext = ContextExamples.helloworldContext
 const mockEvent: APIGatewayProxyEvent = {
   httpMethod: "get",
   body: "",
-  headers: {},
+  headers: {
+    "nhsd-correlation-id": "test-request-id.test-correlation-id.rrt-5789322914740101037-b-aet2-20145-482635-2",
+    "x-request-id": "test-request-id",
+    "nhsd-request-id": "test-request-id",
+    "x-correlation-id": "test-correlation-id"
+  },
   isBase64Encoded: false,
   multiValueHeaders: {},
   multiValueQueryStringParameters: {},
@@ -66,5 +72,18 @@ describe("Unit test for app handler", function () {
     const result: APIGatewayProxyResult = (await handler(mockEvent, dummyContext)) as APIGatewayProxyResult
 
     expect(result.headers).toEqual({"Content-Type": "application/fhir+json"})
+  })
+  it("appends trace id's to the logger", async () => {
+    const mockAppendKeys = jest.spyOn(Logger.prototype, "appendKeys")
+
+    await handler(mockEvent, dummyContext)
+
+    expect(mockAppendKeys).toHaveBeenCalledWith({
+      "nhsd-correlation-id": "test-request-id.test-correlation-id.rrt-5789322914740101037-b-aet2-20145-482635-2",
+      "x-request-id": "test-request-id",
+      "nhsd-request-id": "test-request-id",
+      "x-correlation-id": "test-correlation-id",
+      "apigw-request-id": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef"
+    })
   })
 })

--- a/packages/statusLambda/src/app.ts
+++ b/packages/statusLambda/src/app.ts
@@ -20,7 +20,15 @@ const logger = new Logger({serviceName: "status"})
  */
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const lambdaHandler = async (_event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  logger.appendKeys({
+    "nhsd-correlation-id": event.headers["nhsd-correlation-id"],
+    "x-request-id": event.headers["x-request-id"],
+    "nhsd-request-id": event.headers["nhsd-request-id"],
+    "x-correlation-id": event.headers["x-correlation-id"],
+    "apigw-request-id": event.requestContext.requestId
+  })
+
   const spineClient = createSpineClient()
 
   const spineStatus = await spineClient.getStatus(logger)

--- a/packages/statusLambda/tests/test-handler.test.ts
+++ b/packages/statusLambda/tests/test-handler.test.ts
@@ -2,19 +2,70 @@ import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda"
 import {handler} from "../src/app"
 import {expect, describe, it} from "@jest/globals"
 import {ContextExamples} from "@aws-lambda-powertools/commons"
+import {Logger} from "@aws-lambda-powertools/logger"
 
 const dummyContext = ContextExamples.helloworldContext
+const mockEvent: APIGatewayProxyEvent = {
+  httpMethod: "get",
+  body: "",
+  headers: {
+    "nhsd-correlation-id": "test-request-id.test-correlation-id.rrt-5789322914740101037-b-aet2-20145-482635-2",
+    "x-request-id": "test-request-id",
+    "nhsd-request-id": "test-request-id",
+    "x-correlation-id": "test-correlation-id"
+  },
+  isBase64Encoded: false,
+  multiValueHeaders: {},
+  multiValueQueryStringParameters: {},
+  path: "/hello",
+  pathParameters: {},
+  queryStringParameters: {},
+  requestContext: {
+    accountId: "123456789012",
+    apiId: "1234",
+    authorizer: {},
+    httpMethod: "get",
+    identity: {
+      accessKey: "",
+      accountId: "",
+      apiKey: "",
+      apiKeyId: "",
+      caller: "",
+      clientCert: {
+        clientCertPem: "",
+        issuerDN: "",
+        serialNumber: "",
+        subjectDN: "",
+        validity: {notAfter: "", notBefore: ""}
+      },
+      cognitoAuthenticationProvider: "",
+      cognitoAuthenticationType: "",
+      cognitoIdentityId: "",
+      cognitoIdentityPoolId: "",
+      principalOrgId: "",
+      sourceIp: "",
+      user: "",
+      userAgent: "",
+      userArn: ""
+    },
+    path: "/hello",
+    protocol: "HTTP/1.1",
+    requestId: "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    requestTimeEpoch: 1428582896000,
+    resourceId: "123456",
+    resourcePath: "/hello",
+    stage: "dev"
+  },
+  resource: "",
+  stageVariables: {}
+}
 
 describe("Unit test for status check", function () {
   it("returns commit id from environment", async () => {
     process.env.COMMIT_ID = "test_commit_id"
     process.env.TargetSpineServer = "sandbox"
 
-    const event: Partial<APIGatewayProxyEvent> = {}
-    const result: APIGatewayProxyResult = (await handler(
-      event as APIGatewayProxyEvent,
-      dummyContext
-    )) as APIGatewayProxyResult
+    const result: APIGatewayProxyResult = (await handler(mockEvent, dummyContext)) as APIGatewayProxyResult
 
     expect(result.statusCode).toEqual(200)
     expect(JSON.parse(result.body)).toMatchObject({
@@ -26,15 +77,24 @@ describe("Unit test for status check", function () {
     process.env.VERSION_NUMBER = "test_version_number"
     process.env.TargetSpineServer = "sandbox"
 
-    const event: Partial<APIGatewayProxyEvent> = {}
-    const result: APIGatewayProxyResult = (await handler(
-      event as APIGatewayProxyEvent,
-      dummyContext
-    )) as APIGatewayProxyResult
+    const result: APIGatewayProxyResult = (await handler(mockEvent, dummyContext)) as APIGatewayProxyResult
 
     expect(result.statusCode).toEqual(200)
     expect(JSON.parse(result.body)).toMatchObject({
       versionNumber: "test_version_number"
+    })
+  })
+  it("appends trace id's to the logger", async () => {
+    const mockAppendKeys = jest.spyOn(Logger.prototype, "appendKeys")
+
+    await handler(mockEvent, dummyContext)
+
+    expect(mockAppendKeys).toHaveBeenCalledWith({
+      "nhsd-correlation-id": "test-request-id.test-correlation-id.rrt-5789322914740101037-b-aet2-20145-482635-2",
+      "x-request-id": "test-request-id",
+      "nhsd-request-id": "test-request-id",
+      "x-correlation-id": "test-correlation-id",
+      "apigw-request-id": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef"
     })
   })
 })


### PR DESCRIPTION
Updates the logger to add a variety of trace ids:

- nhsd-correlation-id
- x-request-id
- nhsd-request-id
- x-correlation-id
- apigw-request-id