### PR TITLE
AEA-3452 -  adds x-request-id to res body

### DIFF
--- a/packages/getMyPrescriptions/src/app.ts
+++ b/packages/getMyPrescriptions/src/app.ts
@@ -20,6 +20,7 @@ const logger = new Logger({serviceName: "getMyPrescriptions"})
  */
 
 const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const xRequestId = event.headers["x-request-id"]
   logger.appendKeys({
     "nhsd-correlation-id": event.headers["nhsd-correlation-id"],
     "x-request-id": event.headers["x-request-id"],
@@ -31,9 +32,11 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 
   try {
     const returnData = await spineClient.getPrescriptions(event.headers, logger)
+    const resBody = returnData.data
+    resBody.id = xRequestId
     return {
       statusCode: 200,
-      body: JSON.stringify(returnData.data),
+      body: JSON.stringify(resBody),
       headers: {
         "Content-Type": "application/fhir+json"
       }

--- a/packages/getMyPrescriptions/src/app.ts
+++ b/packages/getMyPrescriptions/src/app.ts
@@ -23,7 +23,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
   const xRequestId = event.headers["x-request-id"]
   logger.appendKeys({
     "nhsd-correlation-id": event.headers["nhsd-correlation-id"],
-    "x-request-id": event.headers["x-request-id"],
+    "x-request-id": xRequestId,
     "nhsd-request-id": event.headers["nhsd-request-id"],
     "x-correlation-id": event.headers["x-correlation-id"],
     "apigw-request-id": event.requestContext.requestId

--- a/packages/getMyPrescriptions/tests/test-handler.test.ts
+++ b/packages/getMyPrescriptions/tests/test-handler.test.ts
@@ -129,7 +129,12 @@ describe("Unit test for app handler", function () {
     const result: APIGatewayProxyResult = (await handler(event, dummyContext)) as APIGatewayProxyResult
 
     expect(result.statusCode).toEqual(200)
-    expect(result.body).toEqual(JSON.stringify({resourceType: "Bundle"}))
+    expect(result.body).toEqual(
+      JSON.stringify({
+        resourceType: "Bundle",
+        id: "test-request-id"
+      })
+    )
     expect(result.headers).toEqual({"Content-Type": "application/fhir+json"})
   })
 


### PR DESCRIPTION
Adds the value of the x-request-id header as the value of the id field in the getMyPrescriptions bundle response