### PR TITLE
AEA-3479 use ncipollo/release-action to create release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
   ###################################
   # Poetry  #########################
   ###################################
-  - package-ecosystem: "python"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,18 +77,18 @@ jobs:
         uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5
         continue-on-error: true
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-            tag: ${{ env.SPEC_VERSION }}
-            commit: ${{  github.sha }}
-            body: |
-              ## Commit message
-              ${{ github.event.head_commit.message }}
-              ## Info
-              [See code diff](${{ github.event.compare }})
-              [Release workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-  
-              It was initialized by [${{ github.event.sender.login }}](${{ github.event.sender.html_url }})
+          tag: ${{ env.SPEC_VERSION }}
+          commit: ${{  github.sha }}
+          body: |
+            ## Commit message
+            ${{ github.event.head_commit.message }}
+            ## Info
+            [See code diff](${{ github.event.compare }})
+            [Release workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            It was initialized by [${{ github.event.sender.login }}](${{ github.event.sender.html_url }})
 
       - name: output SPEC_VERSION
         id: output_spec_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,21 +71,24 @@ jobs:
         run: echo "SPEC_VERSION=${{  github.ref_name }}" >> $GITHUB_ENV
         if: github.ref != 'refs/heads/main'
 
-      - name: Create github release
-        uses: actions/create-release@v1
+      - name: Create release (tags and main)
+        id: create-release
+        # using commit hash for version v1.13.0
+        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5
+        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.SPEC_VERSION }}
-          release_name: ${{ env.SPEC_VERSION }}
-          body: |
-            ## Commit message
-            ${{ github.event.head_commit.message }}
-            ## Info
-            [See code diff](${{ github.event.compare }})
-            [Release workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-            It was initialized by [${{ github.event.sender.login }}](${{ github.event.sender.html_url }})
+            tag: ${{ env.SPEC_VERSION }}
+            commit: ${{  github.sha }}
+            body: |
+              ## Commit message
+              ${{ github.event.head_commit.message }}
+              ## Info
+              [See code diff](${{ github.event.compare }})
+              [Release workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+  
+              It was initialized by [${{ github.event.sender.login }}](${{ github.event.sender.html_url }})
 
       - name: output SPEC_VERSION
         id: output_spec_version


### PR DESCRIPTION
## Summary

**Remove items from this list if they are not relevant. Remove this line once this has been done**

- Routine Change
- Fix python settings for dependabot 

### Details

- Use https://github.com/ncipollo/release-action to create a release as actions/create-release@v1 is not supported
- Use correct config for dependabot python

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
