### PR TITLE
AEA-3690 log spine duration

### DIFF
--- a/packages/getMyPrescriptions/src/getMyPrescriptions.ts
+++ b/packages/getMyPrescriptions/src/getMyPrescriptions.ts
@@ -30,7 +30,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     "x-correlation-id": event.headers["x-correlation-id"],
     "apigw-request-id": event.requestContext.requestId
   })
-  const spineClient = createSpineClient()
+  const spineClient = createSpineClient(logger)
 
   try {
     const isCertificateConfigured = spineClient.isCertificateConfigured()
@@ -63,7 +63,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
         }
       }
     }
-    const returnData = await spineClient.getPrescriptions(event.headers, logger)
+    const returnData = await spineClient.getPrescriptions(event.headers)
     const resBody = returnData.data
     resBody.id = xRequestId
     return {

--- a/packages/spineClient/src/spine-client.ts
+++ b/packages/spineClient/src/spine-client.ts
@@ -6,15 +6,15 @@ import {APIGatewayProxyEventHeaders} from "aws-lambda"
 import {AxiosResponse} from "axios"
 
 export interface SpineClient {
-  getStatus(logger: Logger): Promise<StatusCheckResponse>
-  getPrescriptions(inboundHeaders: APIGatewayProxyEventHeaders, logger: Logger): Promise<AxiosResponse>
+  getStatus(): Promise<StatusCheckResponse>
+  getPrescriptions(inboundHeaders: APIGatewayProxyEventHeaders): Promise<AxiosResponse>
   isCertificateConfigured(): boolean
 }
 
-export function createSpineClient(): SpineClient {
+export function createSpineClient(logger: Logger): SpineClient {
   const liveMode = process.env.TargetSpineServer !== "sandbox"
   if (liveMode) {
-    return new LiveSpineClient()
+    return new LiveSpineClient(logger)
   } else {
     return new SandboxSpineClient()
   }

--- a/packages/spineClient/src/status.ts
+++ b/packages/spineClient/src/status.ts
@@ -1,5 +1,5 @@
 import {Logger} from "@aws-lambda-powertools/logger"
-import axios, {AxiosError} from "axios"
+import {Axios, AxiosError} from "axios"
 import {Agent} from "https"
 
 export interface StatusCheckResponse {
@@ -10,11 +10,14 @@ export interface StatusCheckResponse {
   links?: string
 }
 
-export async function serviceHealthCheck(url: string, logger: Logger, httpsAgent: Agent): Promise<StatusCheckResponse> {
+export async function serviceHealthCheck(url: string,
+  logger: Logger,
+  httpsAgent: Agent,
+  axiosInstnce: Axios): Promise<StatusCheckResponse> {
   try {
     logger.info(`making request to ${url}`)
 
-    const response = await axios.get<string>(url, {timeout: 20000, httpsAgent})
+    const response = await axiosInstnce.get<string>(url, {timeout: 20000, httpsAgent})
     return {
       status: response.status === 200 ? "pass" : "error",
       timeout: "false",

--- a/packages/spineClient/tests/status.test.ts
+++ b/packages/spineClient/tests/status.test.ts
@@ -6,6 +6,7 @@ import {Agent} from "https"
 import {Logger} from "@aws-lambda-powertools/logger"
 
 const mock = new MockAdapter(axios)
+const axiosInstance = axios.create()
 
 describe("Health check", () => {
   const logger = new Logger({serviceName: "spineClient"})
@@ -18,7 +19,7 @@ describe("Health check", () => {
   test("Successful health check result returns success", async () => {
     mock.onGet("/healthcheck").reply(200, {})
 
-    const spineResponse = await serviceHealthCheck("healthcheck", logger, httpsAgent)
+    const spineResponse = await serviceHealthCheck("healthcheck", logger, httpsAgent, axiosInstance)
 
     expect(spineResponse.status).toBe("pass")
     expect(spineResponse.responseCode).toBe(200)
@@ -29,7 +30,7 @@ describe("Health check", () => {
   test("Failure health check result returns failure", async () => {
     mock.onGet("/healthcheck").reply(500, {})
 
-    const spineResponse = await serviceHealthCheck("healthcheck", logger, httpsAgent)
+    const spineResponse = await serviceHealthCheck("healthcheck", logger, httpsAgent, axiosInstance)
 
     expect(spineResponse.status).toBe("error")
     expect(spineResponse.responseCode).toBe(500)
@@ -40,7 +41,7 @@ describe("Health check", () => {
   test("health check network issues result returns failure", async () => {
     mock.onGet("/healthcheck").networkError()
 
-    const spineResponse = await serviceHealthCheck("healthcheck", logger, httpsAgent)
+    const spineResponse = await serviceHealthCheck("healthcheck", logger, httpsAgent, axiosInstance)
 
     expect(spineResponse.status).toBe("error")
     expect(spineResponse.responseCode).toBe(500)

--- a/packages/statusLambda/src/statusLambda.ts
+++ b/packages/statusLambda/src/statusLambda.ts
@@ -29,7 +29,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     "apigw-request-id": event.requestContext.requestId
   })
 
-  const spineClient = createSpineClient()
+  const spineClient = createSpineClient(logger)
 
   const commitId = process.env.COMMIT_ID
   const versionNumber = process.env.VERSION_NUMBER
@@ -52,7 +52,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
     }
   }
 
-  const spineStatus = await spineClient.getStatus(logger)
+  const spineStatus = await spineClient.getStatus()
 
   return {
     statusCode: 200,


### PR DESCRIPTION
## Summary

- Routine Change

### Details
- refactor spineClient so logger is passed into constructor rather than methods
- use axios interceptor to record start time and log duration

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
