### PR TITLE
use clear state when using inject lambda context

### DIFF
--- a/packages/capabilityStatement/src/capabilityStatement.ts
+++ b/packages/capabilityStatement/src/capabilityStatement.ts
@@ -39,7 +39,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 }
 
 export const handler = middy(lambdaHandler)
-  .use(injectLambdaContext(logger))
+  .use(injectLambdaContext(logger, {clearState: true}))
   .use(
     inputOutputLogger({
       logger: (request) => {

--- a/packages/getMyPrescriptions/src/getMyPrescriptions.ts
+++ b/packages/getMyPrescriptions/src/getMyPrescriptions.ts
@@ -117,7 +117,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 }
 
 export const handler = middy(lambdaHandler)
-  .use(injectLambdaContext(logger))
+  .use(injectLambdaContext(logger, {clearState: true}))
   .use(
     inputOutputLogger({
       logger: (request) => {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -38,7 +38,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 }
 
 export const handler = middy(lambdaHandler)
-  .use(injectLambdaContext(logger))
+  .use(injectLambdaContext(logger, {clearState: true}))
   .use(
     inputOutputLogger({
       logger: (request) => {

--- a/packages/statusLambda/src/statusLambda.ts
+++ b/packages/statusLambda/src/statusLambda.ts
@@ -48,7 +48,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 }
 
 export const handler = middy(lambdaHandler)
-  .use(injectLambdaContext(logger))
+  .use(injectLambdaContext(logger, {clearState: true}))
   .use(
     inputOutputLogger({
       logger: (request) => {


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- when using injectLambdaContext, use clearState to ensure appendKeys uses the correct values - see https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/#clearing-all-state

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
