### PR TITLE
Fix delete_old_cloudformation_stacks script

### DIFF
--- a/.github/scripts/delete_stacks.sh
+++ b/.github/scripts/delete_stacks.sh
@@ -2,7 +2,7 @@
 
 ACTIVE_STACKS=$(aws cloudformation list-stacks | jq -r '.StackSummaries[] | select ( .StackStatus != "DELETE_COMPLETE" ) | select( .StackName | capture("^pr-(sandbox-)?(\\d+)$") ) | .StackName ')
 
-ACTIVE_STACKS_ARRAY=( "$ACTIVE_STACKS" )
+read -ar ACTIVE_STACKS_ARRAY <<< "$ACTIVE_STACKS"
 
 for i in "${ACTIVE_STACKS_ARRAY[@]}"
 do 

--- a/.github/scripts/delete_stacks.sh
+++ b/.github/scripts/delete_stacks.sh
@@ -2,7 +2,7 @@
 
 ACTIVE_STACKS=$(aws cloudformation list-stacks | jq -r '.StackSummaries[] | select ( .StackStatus != "DELETE_COMPLETE" ) | select( .StackName | capture("^pr-(sandbox-)?(\\d+)$") ) | .StackName ')
 
-read -ar ACTIVE_STACKS_ARRAY <<< "$ACTIVE_STACKS"
+read -ra ACTIVE_STACKS_ARRAY <<< "$ACTIVE_STACKS"
 
 for i in "${ACTIVE_STACKS_ARRAY[@]}"
 do 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Fixed bug spotted by Ant. Introduced by double quoting in array assignment. Introuduced as part of AEA-3622