### PR TITLE
AEA-3799 handle no url returned for a distance selling pharmacy

### DIFF
--- a/packages/serviceSearchClient/src/live-serviceSearch-client.ts
+++ b/packages/serviceSearchClient/src/live-serviceSearch-client.ts
@@ -89,6 +89,10 @@ export class LiveServiceSearchClient implements ServiceSearchClient {
       const service = services[0]
       const urlString = service["URL"]
 
+      if (urlString === null) {
+        this.logger.warn(`ods code ${odsCode} has no URL but is of type ${DISTANCE_SELLING}`, {odsCode: odsCode})
+        return undefined
+      }
       const serviceUrl = handleUrl(urlString, odsCode, this.logger)
       return serviceUrl
     } catch (error) {

--- a/packages/serviceSearchClient/tests/live-serviceSearch-client.test.ts
+++ b/packages/serviceSearchClient/tests/live-serviceSearch-client.test.ts
@@ -121,4 +121,15 @@ describe("live serviceSearch client", () => {
       "serviceSearch request duration", {"serviceSearch_duration": expect.any(Number)}
     )
   })
+
+  test("handle null url", async () => {
+    mock.onGet(serviceSearchUrl).reply(200, {value: [{URL: null, OrganisationSubType: "DistanceSelling"}]})
+    const mockLoggerWarn = jest.spyOn(Logger.prototype, "warn")
+    const result = await serviceSearchClient.searchService("no_url")
+    expect(result).toEqual(undefined)
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "ods code no_url has no URL but is of type DistanceSelling", {"odsCode": "no_url"}
+    )
+  })
+
 })

--- a/packages/serviceSearchClient/tests/live-serviceSearch-client.test.ts
+++ b/packages/serviceSearchClient/tests/live-serviceSearch-client.test.ts
@@ -125,11 +125,13 @@ describe("live serviceSearch client", () => {
   test("handle null url", async () => {
     mock.onGet(serviceSearchUrl).reply(200, {value: [{URL: null, OrganisationSubType: "DistanceSelling"}]})
     const mockLoggerWarn = jest.spyOn(Logger.prototype, "warn")
+    const mockLoggerError = jest.spyOn(Logger.prototype, "error")
     const result = await serviceSearchClient.searchService("no_url")
     expect(result).toEqual(undefined)
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       "ods code no_url has no URL but is of type DistanceSelling", {"odsCode": "no_url"}
     )
+    expect(mockLoggerError).not.toHaveBeenCalled()
   })
 
 })


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- cleanly handle no url returned for a distance selling pharmacy
