### PR TITLE
AEA-3979 Do not call NPPT Service to update tracking status if item status of 'Prescriber Approved' or 'Cancelled' is returned from Spine

### DIFF
--- a/packages/common/testing/src/mockAPIResponseBody.json
+++ b/packages/common/testing/src/mockAPIResponseBody.json
@@ -70,7 +70,25 @@
               },
               "substitution": {
                 "allowedBoolean": false
-              }
+              },
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+                  "extension": [
+                    {
+                      "url": "status",
+                      "valueCoding": {
+                        "system": "https://fhir.nhs.uk/CodeSystem/task-businessStatus-nppt",
+                        "code": "Ready to Collect - Partial"
+                      }
+                    },
+                    {
+                      "url": "statusDate",
+                      "valueDateTime": "2023-09-11T10:11:17.000Z"
+                    }
+                  ]
+                }
+              ]
             }
           },
           {

--- a/packages/common/testing/src/mockInteractionResponseBody.json
+++ b/packages/common/testing/src/mockInteractionResponseBody.json
@@ -70,7 +70,25 @@
               },
               "substitution": {
                 "allowedBoolean": false
-              }
+              },
+              "extension": [
+                {
+                  "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionStatusHistory",
+                  "extension": [
+                    {
+                      "url": "status",
+                      "valueCoding": {
+                        "system": "https://fhir.nhs.uk/CodeSystem/task-businessStatus-nppt",
+                        "code": "Ready to Collect - Partial"
+                      }
+                    },
+                    {
+                      "url": "statusDate",
+                      "valueDateTime": "2023-09-11T10:11:17.000Z"
+                    }
+                  ]
+                }
+              ]
             }
           },
           {


### PR DESCRIPTION
## Summary

🎫 [AEA-3979](https://nhsd-jira.digital.nhs.uk/browse/AEA-3979) Do not call NPPT Service to update tracking status if item status of 'Prescriber Approved' or 'Cancelled' is returned from Spine

- :sparkles: New Feature

### Details

As Spine is currently only checking prescription status and not checking line item statuses or those that were cancelled, if all items on the prescription already have status of 'Prescriber Approved' or 'Cancelled', then we can remove this prescription from the query.
However, if it's just one item, then we have to do the point when we get the data back and do the consolidation, we have to say if there is already a status on the prescription, then dont't use this from GSOL. That will be NPPT status on the prescription - if it is 'Prescriber Approved' or 'Cancelled' then we need to ignore or not get the status from GSOL.
Do not query the entire prescription if we don't need the data, because that removes the query from the DynamoDB. If it only some of the items need to be ignored then we may as well do in the image prescription step.
