### PR TITLE
Fix: [AEA-0000] - change esbuild to bundle dependendencies

### DIFF
--- a/SAMtemplates/functions/main.yaml
+++ b/SAMtemplates/functions/main.yaml
@@ -83,6 +83,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: getMyPrescriptions/tsconfig.json
+        packages: bundle
         EntryPoints:
           - getMyPrescriptions/src/getMyPrescriptions.ts
 
@@ -121,6 +122,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: enrichPrescriptions/tsconfig.json
+        packages: bundle
         EntryPoints:
           - enrichPrescriptions/src/enrichPrescriptions.ts
 
@@ -152,6 +154,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: capabilityStatement/tsconfig.json
+        packages: bundle
         EntryPoints:
           - capabilityStatement/src/capabilityStatement.ts
 
@@ -190,6 +193,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: statusLambda/tsconfig.json
+        packages: bundle
         EntryPoints:
           - statusLambda/src/statusLambda.ts
 

--- a/SAMtemplates/main_template.old.yaml
+++ b/SAMtemplates/main_template.old.yaml
@@ -147,6 +147,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: getMyPrescriptions/tsconfig.json
+        packages: bundle
         EntryPoints:
           - getMyPrescriptions/src/getMyPrescriptions.ts
 
@@ -183,6 +184,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: capabilityStatement/tsconfig.json
+        packages: bundle
         EntryPoints:
           - capabilityStatement/src/capabilityStatement.ts
 
@@ -227,6 +229,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: statusLambda/tsconfig.json
+        packages: bundle
         EntryPoints:
           - statusLambda/src/statusLambda.ts
 

--- a/SAMtemplates/sandbox_template.yaml
+++ b/SAMtemplates/sandbox_template.yaml
@@ -132,6 +132,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: sandbox/tsconfig.json
+        packages: bundle
         EntryPoints:
           - sandbox/src/sandbox.ts
 
@@ -171,6 +172,7 @@ Resources:
         Target: es2020
         Sourcemap: true
         tsconfig: capabilityStatement/tsconfig.json
+        packages: bundle
         EntryPoints:
           - capabilityStatement/src/capabilityStatement.ts
 
@@ -214,6 +216,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: statusLambda/tsconfig.json
+        packages: bundle
         EntryPoints:
           - statusLambda/src/statusLambda.ts
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- change esbuild to bundle dependencies following default behavior in esbuild 0.22 - https://github.com/evanw/esbuild/releases/tag/v0.22.0