### PR TITLE
Fix: [AEA-0000] - allow dependabot to get private npm package 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,12 @@
 #########################################################################
 
 version: 2
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.DEPENDABOT_TOKEN}}
+
 updates:
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -24,6 +30,8 @@ updates:
     open-pull-requests-limit: 20
     commit-message:
       prefix: "Upgrade: [dependabot] - "
+    registries:
+      - npm-github
 
   ###################################
   # Poetry  #########################


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- access private npm registry for dependabot