### PR TITLE
Chore: [AEA-4489] - Add concurrency alarm

### DIFF
--- a/SAMtemplates/alarms/main.yaml
+++ b/SAMtemplates/alarms/main.yaml
@@ -90,7 +90,7 @@ Resources:
   PfPConcurrencyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties: 
-      AlarmName: !Sub "${StackName}-Concurrency-Alarm"
+      AlarmName: !Sub "${StackName}_Concurrency_Alarm"
       AlarmDescription: "Monitors the concurrency of the PfP as a whole and triggers when concurrency exceeds the threshold."
       Namespace: "AWS/Lambda"
       MetricName: "ConcurrentExecutions"

--- a/SAMtemplates/alarms/main.yaml
+++ b/SAMtemplates/alarms/main.yaml
@@ -94,12 +94,12 @@ Resources:
       AlarmDescription: "Monitors the concurrency of the PfP as a whole and triggers when concurrency exceeds the threshold."
       Namespace: "AWS/Lambda"
       MetricName: "ConcurrentExecutions"
-      Statistic: Sum
+      Statistic: Maximum
       Period: 60 # seconds
       EvaluationPeriods: 1
       Threshold: !Ref ConcurrencyThreshold
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
+      TreatMissingData: breaching
       ActionsEnabled: !Ref EnableAlerts
       AlarmActions:
         - !ImportValue lambda-resources:SlackAlertsSnsTopicArn

--- a/SAMtemplates/alarms/main.yaml
+++ b/SAMtemplates/alarms/main.yaml
@@ -15,6 +15,10 @@ Parameters:
   EnableAlerts:
     Type: String
 
+  ConcurrencyThreshold:
+    Type: Number
+    Default: 100000
+
 Resources:
   ServiceSearchErrorsLogsMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -74,6 +78,27 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       Unit: Count
+      TreatMissingData: notBreaching
+      ActionsEnabled: !Ref EnableAlerts
+      AlarmActions:
+        - !ImportValue lambda-resources:SlackAlertsSnsTopicArn
+      InsufficientDataActions:
+        - !ImportValue lambda-resources:SlackAlertsSnsTopicArn
+      OKActions:
+        - !ImportValue lambda-resources:SlackAlertsSnsTopicArn
+
+  PfPConcurrencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties: 
+      AlarmName: !Sub "${StackName}-Concurrency-Alarm"
+      AlarmDescription: "Monitors the concurrency of the PfP as a whole and triggers when concurrency exceeds the threshold."
+      Namespace: "AWS/Lambda"
+      MetricName: "ConcurrentExecutions"
+      Statistic: Sum
+      Period: 60 # seconds
+      EvaluationPeriods: 1
+      Threshold: !Ref ConcurrencyThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       ActionsEnabled: !Ref EnableAlerts
       AlarmActions:

--- a/SAMtemplates/main_template.yaml
+++ b/SAMtemplates/main_template.yaml
@@ -137,4 +137,4 @@ Resources:
         StackName: !Ref AWS::StackName
         GetMyPrescriptionsFunctionName: !GetAtt Functions.Outputs.GetMyPrescriptionsFunctionName
         EnableAlerts: !Ref EnableAlerts
-        ConcurrencyThreshold: 10 #FIXME: Set appropriate threshold based on load tests.
+        ConcurrencyThreshold: 10000 #FIXME: Set appropriate threshold based on load tests.

--- a/SAMtemplates/main_template.yaml
+++ b/SAMtemplates/main_template.yaml
@@ -137,3 +137,4 @@ Resources:
         StackName: !Ref AWS::StackName
         GetMyPrescriptionsFunctionName: !GetAtt Functions.Outputs.GetMyPrescriptionsFunctionName
         EnableAlerts: !Ref EnableAlerts
+        ConcurrencyThreshold: 10 #FIXME: Set appropriate threshold based on load tests.


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change
- :sparkles: New Feature

### Details

Add a concurrency alarm. If `X` users submit requests to the PfP within a minute, the alarm will trigger. 