### PR TITLE
Fix: [AEA-4489] - Adjust concurrency alarm parameters

### DIFF
--- a/SAMtemplates/alarms/main.yaml
+++ b/SAMtemplates/alarms/main.yaml
@@ -95,7 +95,7 @@ Resources:
       Namespace: "AWS/Lambda"
       MetricName: "ConcurrentExecutions"
       Statistic: Maximum
-      Period: 60 # seconds
+      Period: 300 # seconds
       EvaluationPeriods: 1
       Threshold: !Ref ConcurrencyThreshold
       ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/SAMtemplates/alarms/main.yaml
+++ b/SAMtemplates/alarms/main.yaml
@@ -99,7 +99,7 @@ Resources:
       EvaluationPeriods: 1
       Threshold: !Ref ConcurrencyThreshold
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: breaching
+      TreatMissingData: notBreaching
       ActionsEnabled: !Ref EnableAlerts
       AlarmActions:
         - !ImportValue lambda-resources:SlackAlertsSnsTopicArn

--- a/SAMtemplates/main_template.yaml
+++ b/SAMtemplates/main_template.yaml
@@ -137,4 +137,4 @@ Resources:
         StackName: !Ref AWS::StackName
         GetMyPrescriptionsFunctionName: !GetAtt Functions.Outputs.GetMyPrescriptionsFunctionName
         EnableAlerts: !Ref EnableAlerts
-        ConcurrencyThreshold: 10000 #FIXME: Set appropriate threshold based on load tests.
+        ConcurrencyThreshold: 350


### PR DESCRIPTION
## Summary

**Remove items from this list if they are not relevant. Remove this line once this has been done**

- :robot: Operational or Infrastructure Change

### Details

The PfP concurrency alarm keeps going off. We need to make missing data non-breaching to prevent that.