### PR TITLE
Fix: [AEA-5560] - Additional logging to support notify integration

### DIFF
--- a/packages/getMyPrescriptions/src/getMyPrescriptions.ts
+++ b/packages/getMyPrescriptions/src/getMyPrescriptions.ts
@@ -110,6 +110,8 @@ async function eventHandler(
       logger.error("Operation outcome returned from spine", {operationOutcome})
     })
 
+    logger.debug("JIM-LOG", {searchsetBundle})
+
     const statusUpdateData = includeStatusUpdateData ? buildStatusUpdateData(logger, searchsetBundle) : undefined
 
     const distanceSelling = new DistanceSelling(servicesCache, logger)


### PR DESCRIPTION
## Summary

- Routine Change

### Details

The existing query for 5560 relies on a debug log. We need additional info-level logging to support the statistics we want to gather.